### PR TITLE
[BE] API Server - 전체 Todo 조회 요청 기능 구현

### DIFF
--- a/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
+++ b/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("api")
@@ -26,7 +25,7 @@ public class TodoController {
 	}
 
 	@GetMapping("/todos")
-	public Optional<List> todoList() {
+	public List<Todo> todoList() {
 		return todoService.findTodos();
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
+++ b/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+import java.util.Optional;
+
 @RestController
 @RequestMapping("api")
 public class TodoController {
@@ -20,5 +23,10 @@ public class TodoController {
 	@GetMapping("/todos/{id}")
 	public Todo getById(@PathVariable Long id) {
 		return todoService.getById(id);
+	}
+
+	@GetMapping("/todos")
+	public Optional<List> todoList() {
+		return todoService.findTodos();
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
+++ b/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
@@ -2,7 +2,6 @@ package codesquad.be.todoserver.controller;
 
 import codesquad.be.todoserver.domain.Todo;
 import codesquad.be.todoserver.service.TodoService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api")
 public class TodoController {
 
-	@Autowired
 	private TodoService todoService;
 
 	public TodoController(TodoService todoService) {

--- a/BE/src/main/java/codesquad/be/todoserver/domain/Todo.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/Todo.java
@@ -9,14 +9,14 @@ public class Todo {
 	private final String contents;
 	private final String user;
 	private final String status;
-	private LocalDateTime createdTime;
-	private LocalDateTime updatedTime;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 
-	public Todo(Long id, String title, String contents, String userId, String status) {
+	public Todo(Long id, String title, String contents, String user, String status) {
 		this.id = id;
 		this.title = title;
 		this.contents = contents;
-		this.user = userId;
+		this.user = user;
 		this.status = status;
 	}
 
@@ -51,11 +51,11 @@ public class Todo {
 		this.id = id;
 	}
 
-	public void setCreatedTime(LocalDateTime createdTime) {
-		this.createdTime = createdTime;
+	public void setCreatedAt(LocalDateTime createdAt) {
+		this.createdAt = createdAt;
 	}
 
-	public void setUpdatedTime(LocalDateTime updatedTime) {
-		this.updatedTime = updatedTime;
+	public void setUpdatedAt(LocalDateTime updatedAt) {
+		this.updatedAt = updatedAt;
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -1,18 +1,16 @@
 package codesquad.be.todoserver.repository;
 
 import codesquad.be.todoserver.domain.Todo;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public class TodoJdbcRepository implements TodoRepository {
 
-	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
 	public TodoJdbcRepository(JdbcTemplate jdbcTemplate) {
@@ -35,8 +33,8 @@ public class TodoJdbcRepository implements TodoRepository {
 				rs.getString("user"),
 				rs.getString("status"));
 			todo.setId(rs.getLong("id"));
-			todo.setCreatedTime(rs.getObject("created_time", LocalDateTime.class));
-			todo.setUpdatedTime(rs.getObject("updated_time", LocalDateTime.class));
+			todo.setCreatedAt(rs.getTimestamp("created_time").toLocalDateTime());
+			todo.setUpdatedAt(rs.getTimestamp("updated_time").toLocalDateTime());
 			return todo;
 		};
 	}

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -26,7 +26,7 @@ public class TodoJdbcRepository implements TodoRepository {
 	}
 
 	@Override
-	public Optional<List> findAll() {
+	public Optional<List> findAllTodos() {
 		String sql = "SELECT id, title, contents, user, status, created_time, updated_time FROM TODO";
 		List<Todo> todos = jdbcTemplate.query(sql, todoRowMapper());
 		return Optional.of(todos);

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -25,6 +25,13 @@ public class TodoJdbcRepository implements TodoRepository {
 		return todos.stream().findAny();
 	}
 
+	@Override
+	public Optional<List> findAll() {
+		String sql = "SELECT id, title, contents, user, status, created_time, updated_time FROM TODO";
+		List<Todo> todos = jdbcTemplate.query(sql, todoRowMapper());
+		return Optional.of(todos);
+	}
+
 	public RowMapper<Todo> todoRowMapper() {
 		return (rs, rowNum) -> {
 			Todo todo = new Todo(

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
@@ -11,5 +11,5 @@ public interface TodoRepository {
 
 	Optional<Todo> findById(Long id);
 
-	Optional<List> findAll();
+	Optional<List> findAllTodos();
 }

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
@@ -1,11 +1,15 @@
 package codesquad.be.todoserver.repository;
 
 import codesquad.be.todoserver.domain.Todo;
-import java.util.Optional;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TodoRepository {
 
 	Optional<Todo> findById(Long id);
+
+	Optional<List> findAll();
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -5,6 +5,9 @@ import codesquad.be.todoserver.exception.NoSuchTodoFoundException;
 import codesquad.be.todoserver.repository.TodoRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+
 @Service
 public class TodoService {
 
@@ -16,6 +19,10 @@ public class TodoService {
 
 	public Todo getById(Long id) {
 		return todoRepository.findById(id)
-			.orElseThrow(() -> new NoSuchTodoFoundException("조회할 수 없는 Todo 입니다. id : " + id));
+			.orElseThrow(() -> new NoSuchTodoFoundException("id: " + id));
+	}
+
+	public Optional<List> findTodos() {
+		return todoRepository.findAll();
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -3,13 +3,11 @@ package codesquad.be.todoserver.service;
 import codesquad.be.todoserver.domain.Todo;
 import codesquad.be.todoserver.exception.NoSuchTodoFoundException;
 import codesquad.be.todoserver.repository.TodoRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TodoService {
 
-	@Autowired
 	private TodoRepository todoRepository;
 
 	public TodoService(TodoRepository todoRepository) {

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -6,7 +6,7 @@ import codesquad.be.todoserver.repository.TodoRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.NoSuchElementException;
 
 @Service
 public class TodoService {
@@ -22,7 +22,8 @@ public class TodoService {
 			.orElseThrow(() -> new NoSuchTodoFoundException("id: " + id));
 	}
 
-	public Optional<List> findTodos() {
-		return todoRepository.findAll();
+	public List<Todo> findTodos() {
+		return todoRepository.findAllTodos()
+				.orElseThrow(() -> new NoSuchElementException("Empty Todos"));
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
@@ -1,10 +1,5 @@
 package codesquad.be.todoserver.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import codesquad.be.todoserver.domain.Todo;
 import codesquad.be.todoserver.exception.NoSuchTodoFoundException;
 import codesquad.be.todoserver.service.TodoService;
@@ -15,6 +10,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TodoController.class)
 @DisplayName("API /api/todos/* 컨트롤러 계층 단위 테스트")
@@ -45,11 +49,40 @@ class TodoControllerTest {
 	@Test
 	void 특정_투두리스트_조회_실패() throws Exception {
 		given(todoService.getById(4444L))
-			.willThrow(new NoSuchTodoFoundException("조회할 수 없는 Todo 입니다. id : " + 4444));
+			.willThrow(new NoSuchTodoFoundException("id: " + 4444));
 
 		ResultActions perform = mockMvc.perform(get("/api/todos/4444"));
 
 		perform
 			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	void 전체_투두_조회_성공() throws Exception {
+		List<Todo> arr = new ArrayList<>();
+		arr.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
+		arr.add(new Todo(2L, "블로그에 포스팅할 것", "*Github 공부내용 \n" +
+				" *모던 자바스크립트 1장 공부내용", "sam", "todo"));
+
+		given(todoService.findTodos())
+				.willReturn(Optional.of(arr));
+
+		ResultActions perform = mockMvc.perform(get("/api/todos"));
+
+		perform
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.[0].id").value(1))
+				.andExpect(jsonPath("$.[0].title").value("Github 공부하기"))
+				.andExpect(jsonPath("$.[0].contents").value("add, commit, push"))
+				.andExpect(jsonPath("$.[0].user").value("sam"))
+				.andExpect(jsonPath("$.[0].status").value("todo"))
+
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.[1].id").value(2))
+				.andExpect(jsonPath("$.[1].title").value("블로그에 포스팅할 것"))
+				.andExpect(jsonPath("$.[1].contents").value("*Github 공부내용 \n" +
+						" *모던 자바스크립트 1장 공부내용"))
+				.andExpect(jsonPath("$.[1].user").value("sam"))
+				.andExpect(jsonPath("$.[1].status").value("todo"));
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
@@ -59,13 +59,10 @@ class TodoControllerTest {
 
 	@Test
 	void 전체_투두_조회_성공() throws Exception {
-		List<Todo> arr = new ArrayList<>();
-		arr.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
-		arr.add(new Todo(2L, "블로그에 포스팅할 것", "*Github 공부내용 \n" +
-				" *모던 자바스크립트 1장 공부내용", "sam", "todo"));
+		List<Todo> todos = createTestData();
 
 		given(todoService.findTodos())
-				.willReturn(Optional.of(arr));
+				.willReturn(Optional.of(todos));
 
 		ResultActions perform = mockMvc.perform(get("/api/todos"));
 
@@ -84,5 +81,13 @@ class TodoControllerTest {
 						" *모던 자바스크립트 1장 공부내용"))
 				.andExpect(jsonPath("$.[1].user").value("sam"))
 				.andExpect(jsonPath("$.[1].status").value("todo"));
+	}
+
+	private List<Todo> createTestData() {
+		List<Todo> todos = new ArrayList<>();
+		todos.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
+		todos.add(new Todo(2L, "블로그에 포스팅할 것", "*Github 공부내용 \n" +
+				" *모던 자바스크립트 1장 공부내용", "sam", "todo"));
+		return todos;
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -62,7 +61,7 @@ class TodoControllerTest {
 		List<Todo> todos = createTestData();
 
 		given(todoService.findTodos())
-				.willReturn(Optional.of(todos));
+				.willReturn(todos);
 
 		ResultActions perform = mockMvc.perform(get("/api/todos"));
 

--- a/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,5 +44,24 @@ class TodoRepositoryTest {
 		Optional<Todo> todo = todoRepository.findById(4444L);
 
 		assertThat(todo).isEmpty();
+	}
+
+	@Test
+	void 전체_투두리스트_조회_성공() {
+		List<Todo> todos = todoRepository.findAll().get();
+
+		assertAll(
+				() -> assertThat(todos.get(0).getId()).isEqualTo(1),
+				() -> assertThat(todos.get(0).getTitle()).isEqualTo("Github 공부하기"),
+				() -> assertThat(todos.get(0).getContents()).isEqualTo("add, commit, push"),
+				() -> assertThat(todos.get(0).getUser()).isEqualTo("sam"),
+				() -> assertThat(todos.get(0).getStatus()).isEqualTo("todo"),
+
+				() -> assertThat(todos.get(1).getId()).isEqualTo(2),
+				() -> assertThat(todos.get(1).getTitle()).isEqualTo("블로그에 포스팅할 것"),
+				() -> assertThat(todos.get(1).getContents()).isEqualTo("*Github 공부내용 \\r\\n" + " *모던 자바스크립트 1장 공부내용"),
+				() -> assertThat(todos.get(1).getUser()).isEqualTo("sam"),
+				() -> assertThat(todos.get(1).getStatus()).isEqualTo("todo")
+		);
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
@@ -1,16 +1,20 @@
 package codesquad.be.todoserver.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import codesquad.be.todoserver.domain.Todo;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJdbcTest
+@Sql({"/db/schema.sql", "/db/data.sql"})
 @DisplayName("API /api/todos/* 리포지토리 계층 단위 테스트")
 class TodoRepositoryTest {
 
@@ -25,17 +29,19 @@ class TodoRepositoryTest {
 	void 특정_투두리스트_조회_성공() {
 		Todo todo = todoRepository.findById(1L).get();
 
-		assertThat(todo.getId()).isEqualTo(1);
-		assertThat(todo.getTitle()).isEqualTo("Github 공부하기");
-		assertThat(todo.getContents()).isEqualTo("add, commit, push");
-		assertThat(todo.getUser()).isEqualTo("sam");
-		assertThat(todo.getStatus()).isEqualTo("todo");
+		assertAll(
+				() -> assertThat(todo.getId()).isEqualTo(1),
+				() -> assertThat(todo.getTitle()).isEqualTo("Github 공부하기"),
+				() -> assertThat(todo.getContents()).isEqualTo("add, commit, push"),
+				() -> assertThat(todo.getUser()).isEqualTo("sam"),
+				() -> assertThat(todo.getStatus()).isEqualTo("todo")
+		);
 	}
 
 	@Test
 	void 특정_투두리스트_조회_실패() {
 		Optional<Todo> todo = todoRepository.findById(4444L);
 
-		assertThat(todo.isPresent()).isFalse();
+		assertThat(todo).isEmpty();
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
@@ -48,20 +48,8 @@ class TodoRepositoryTest {
 
 	@Test
 	void 전체_투두리스트_조회_성공() {
-		List<Todo> todos = todoRepository.findAll().get();
+		List<Todo> todos = todoRepository.findAllTodos().get();
 
-		assertAll(
-				() -> assertThat(todos.get(0).getId()).isEqualTo(1),
-				() -> assertThat(todos.get(0).getTitle()).isEqualTo("Github 공부하기"),
-				() -> assertThat(todos.get(0).getContents()).isEqualTo("add, commit, push"),
-				() -> assertThat(todos.get(0).getUser()).isEqualTo("sam"),
-				() -> assertThat(todos.get(0).getStatus()).isEqualTo("todo"),
-
-				() -> assertThat(todos.get(1).getId()).isEqualTo(2),
-				() -> assertThat(todos.get(1).getTitle()).isEqualTo("블로그에 포스팅할 것"),
-				() -> assertThat(todos.get(1).getContents()).isEqualTo("*Github 공부내용 \\r\\n" + " *모던 자바스크립트 1장 공부내용"),
-				() -> assertThat(todos.get(1).getUser()).isEqualTo("sam"),
-				() -> assertThat(todos.get(1).getStatus()).isEqualTo("todo")
-		);
+		assertThat(todos).hasSize(4);
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
@@ -4,9 +4,12 @@ import codesquad.be.todoserver.domain.Todo;
 import codesquad.be.todoserver.exception.NoSuchTodoFoundException;
 import codesquad.be.todoserver.repository.TodoRepository;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,5 +50,31 @@ class TodoServiceTest {
 
 		assertThatThrownBy(() -> todoService.getById(id))
 			.isInstanceOf(NoSuchTodoFoundException.class);
+	}
+
+	@Test
+	void 전체_투두리스트_조회_성공() {
+		List<Todo> todoList = new ArrayList<>();
+		todoList.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
+		todoList.add(new Todo(2L, "블로그에 포스팅할 것", "*Github 공부내용 \n" + " *모던 자바스크립트 1장 공부내용", "sam", "todo"));
+
+		given(todoRepository.findAll())
+				.willReturn(Optional.of(todoList));
+
+		List<Todo> todos = todoService.findTodos().get();
+
+		assertAll(
+				() -> assertThat(todos.get(0).getId()).isEqualTo(1),
+				() -> assertThat(todos.get(0).getTitle()).isEqualTo("Github 공부하기"),
+				() -> assertThat(todos.get(0).getContents()).isEqualTo("add, commit, push"),
+				() -> assertThat(todos.get(0).getUser()).isEqualTo("sam"),
+				() -> assertThat(todos.get(0).getStatus()).isEqualTo("todo"),
+
+				() -> assertThat(todos.get(1).getId()).isEqualTo(2),
+				() -> assertThat(todos.get(1).getTitle()).isEqualTo("블로그에 포스팅할 것"),
+				() -> assertThat(todos.get(1).getContents()).isEqualTo("*Github 공부내용 \n" + " *모던 자바스크립트 1장 공부내용"),
+				() -> assertThat(todos.get(1).getUser()).isEqualTo("sam"),
+				() -> assertThat(todos.get(1).getStatus()).isEqualTo("todo")
+		);
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
@@ -54,12 +54,10 @@ class TodoServiceTest {
 
 	@Test
 	void 전체_투두리스트_조회_성공() {
-		List<Todo> todoList = new ArrayList<>();
-		todoList.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
-		todoList.add(new Todo(2L, "블로그에 포스팅할 것", "*Github 공부내용 \n" + " *모던 자바스크립트 1장 공부내용", "sam", "todo"));
+		List<Todo> todolist = createTestData();
 
 		given(todoRepository.findAll())
-				.willReturn(Optional.of(todoList));
+				.willReturn(Optional.of(todolist));
 
 		List<Todo> todos = todoService.findTodos().get();
 
@@ -76,5 +74,12 @@ class TodoServiceTest {
 				() -> assertThat(todos.get(1).getUser()).isEqualTo("sam"),
 				() -> assertThat(todos.get(1).getStatus()).isEqualTo("todo")
 		);
+	}
+
+	private List<Todo> createTestData() {
+		List<Todo> todolist = new ArrayList<>();
+		todolist.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
+		todolist.add(new Todo(2L, "블로그에 포스팅할 것", "*Github 공부내용 \n" + " *모던 자바스크립트 1장 공부내용", "sam", "todo"));
+		return todolist;
 	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
@@ -24,21 +24,20 @@ class TodoServiceTest {
 	private TodoRepository todoRepository = mock(TodoRepository.class);
 	private TodoService todoService = new TodoService(todoRepository);
 
-	@ParameterizedTest
-	@ValueSource(strings = {"Github 공부하기", "add, commit, push", "sam", "todo"})
-	void 특정_투두리스트_조회_성공(String input) {
+	@Test
+	void 특정_투두리스트_조회_성공() {
 		given(todoRepository.findById(1L))
 			.willReturn(
-				Optional.of(new Todo(1L, input, input, input, input)));
+				Optional.of(new Todo(1L,"Github 공부하기", "add, commit, push", "sam", "todo")));
 
 		Todo todo = todoService.getById(1L);
 
 		assertAll(
 				() -> assertThat(todo.getId()).isEqualTo(1),
-				() -> assertThat(todo.getTitle()).isEqualTo(input),
-				() -> assertThat(todo.getContents()).isEqualTo(input),
-				() -> assertThat(todo.getUser()).isEqualTo(input),
-				() -> assertThat(todo.getStatus()).isEqualTo(input)
+				() -> assertThat(todo.getTitle()).isEqualTo("Github 공부하기"),
+				() -> assertThat(todo.getContents()).isEqualTo("add, commit, push"),
+				() -> assertThat(todo.getUser()).isEqualTo("sam"),
+				() -> assertThat(todo.getStatus()).isEqualTo("todo")
 		);
 	}
 
@@ -56,24 +55,13 @@ class TodoServiceTest {
 	void 전체_투두리스트_조회_성공() {
 		List<Todo> todolist = createTestData();
 
-		given(todoRepository.findAll())
+		given(todoRepository.findAllTodos())
 				.willReturn(Optional.of(todolist));
 
-		List<Todo> todos = todoService.findTodos().get();
+		List<Todo> todos = todoService.findTodos();
 
-		assertAll(
-				() -> assertThat(todos.get(0).getId()).isEqualTo(1),
-				() -> assertThat(todos.get(0).getTitle()).isEqualTo("Github 공부하기"),
-				() -> assertThat(todos.get(0).getContents()).isEqualTo("add, commit, push"),
-				() -> assertThat(todos.get(0).getUser()).isEqualTo("sam"),
-				() -> assertThat(todos.get(0).getStatus()).isEqualTo("todo"),
-
-				() -> assertThat(todos.get(1).getId()).isEqualTo(2),
-				() -> assertThat(todos.get(1).getTitle()).isEqualTo("블로그에 포스팅할 것"),
-				() -> assertThat(todos.get(1).getContents()).isEqualTo("*Github 공부내용 \n" + " *모던 자바스크립트 1장 공부내용"),
-				() -> assertThat(todos.get(1).getUser()).isEqualTo("sam"),
-				() -> assertThat(todos.get(1).getStatus()).isEqualTo("todo")
-		);
+		assertThat(todos).contains(todolist.get(0));
+		assertThat(todos).contains(todolist.get(1));
 	}
 
 	private List<Todo> createTestData() {

--- a/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
@@ -1,16 +1,19 @@
 package codesquad.be.todoserver.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-
 import codesquad.be.todoserver.domain.Todo;
 import codesquad.be.todoserver.exception.NoSuchTodoFoundException;
 import codesquad.be.todoserver.repository.TodoRepository;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @DisplayName("API /api/todos/* 서비스 계층 단위 테스트")
 class TodoServiceTest {
@@ -18,27 +21,31 @@ class TodoServiceTest {
 	private TodoRepository todoRepository = mock(TodoRepository.class);
 	private TodoService todoService = new TodoService(todoRepository);
 
-	@Test
-	void 특정_투두리스트_조회_성공() throws Exception {
+	@ParameterizedTest
+	@ValueSource(strings = {"Github 공부하기", "add, commit, push", "sam", "todo"})
+	void 특정_투두리스트_조회_성공(String input) {
 		given(todoRepository.findById(1L))
 			.willReturn(
-				Optional.of(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo")));
+				Optional.of(new Todo(1L, input, input, input, input)));
 
 		Todo todo = todoService.getById(1L);
 
-		assertThat(todo.getId()).isEqualTo(1);
-		assertThat(todo.getTitle()).isEqualTo("Github 공부하기");
-		assertThat(todo.getContents()).isEqualTo("add, commit, push");
-		assertThat(todo.getUser()).isEqualTo("sam");
-		assertThat(todo.getStatus()).isEqualTo("todo");
+		assertAll(
+				() -> assertThat(todo.getId()).isEqualTo(1),
+				() -> assertThat(todo.getTitle()).isEqualTo(input),
+				() -> assertThat(todo.getContents()).isEqualTo(input),
+				() -> assertThat(todo.getUser()).isEqualTo(input),
+				() -> assertThat(todo.getStatus()).isEqualTo(input)
+		);
 	}
 
-	@Test
-	void 특정_투두리스트_조회_실패() throws Exception {
-		given(todoRepository.findById(4444L))
-			.willThrow(new NoSuchTodoFoundException("조회할 수 없는 Todo 입니다. id : " + 4444));
+	@ParameterizedTest
+	@ValueSource(longs = {4444L, 5555L})
+	void 특정_투두리스트_조회_실패(Long id) {
+		given(todoRepository.findById(id))
+			.willThrow(new NoSuchTodoFoundException("조회할 수 없는 Todo 입니다. id : " + id));
 
-		assertThatThrownBy(() -> todoService.getById(4444L))
+		assertThatThrownBy(() -> todoService.getById(id))
 			.isInstanceOf(NoSuchTodoFoundException.class);
 	}
 }


### PR DESCRIPTION
### 📝 Description

- 안드로이드 클라이언트가 전체 Todo 를 조회하도록 기능 구현

### 💽 Commits

**PR 리뷰 반영**
- [PR](https://github.com/codesquad-members-2022/todo-list/pull/67) 리뷰 받은 내용 반영

**성공**
- GET /api/todos 요청 값을 받는다.
- DB 에 있는 Todo 를 List 에 담아 보낸다.
- 응답은 Todo 의 List 형태로 간다 (200 OK)

### 🖼 결과

<img width="417" alt="Screen Shot 2022-04-11 at 5 47 58 PM" src="https://user-images.githubusercontent.com/73376468/162699860-9b6e6c9a-96e0-4f34-9206-81a8125027f4.png">

