### PR TITLE
[BE] API Server - Todo 삭제 기능 구현

### DIFF
--- a/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
+++ b/BE/src/main/java/codesquad/be/todoserver/controller/TodoController.java
@@ -6,6 +6,7 @@ import codesquad.be.todoserver.service.TodoService;
 import java.util.List;
 import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,5 +37,11 @@ public class TodoController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public Todo registerTodo(@Valid @RequestBody RegisterTodoDto registerTodoDto) {
 		return todoService.registerTodo(registerTodoDto);
+	}
+
+	@DeleteMapping("/todos/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteTodo(@PathVariable Long id) {
+		todoService.deleteById(id);
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/domain/Action.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/Action.java
@@ -1,0 +1,8 @@
+package codesquad.be.todoserver.domain;
+
+public enum Action {
+	ADD,
+	REMOVE,
+	MOVE,
+	UPDATE;
+}

--- a/BE/src/main/java/codesquad/be/todoserver/domain/History.java
+++ b/BE/src/main/java/codesquad/be/todoserver/domain/History.java
@@ -40,9 +40,19 @@ public class History {
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public static History createAddHistoryBy(Todo todo) {
-		return new History(todo.getId(), todo.getTitle(), todo.getUser(), "add",
-			"", todo.getStatus());
+	public static History of(Todo todo, Action action) {
+		switch (action) {
+			case ADD:
+				return new History(todo.getId(), todo.getTitle(), todo.getUser(), "add",
+					"", todo.getStatus());
+			case REMOVE:
+				return new History(todo.getId(), todo.getTitle(), todo.getUser(), "remove",
+					"", todo.getStatus());
+			case MOVE:
+			case UPDATE:
+				break;
+		}
+		return null;
 	}
 
 }

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -22,7 +22,7 @@ public class TodoJdbcRepository implements TodoRepository {
 
 	@Override
 	public Optional<Todo> findById(Long id) {
-		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO WHERE id = ?";
+		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO WHERE id = ? AND DELETED = 0";
 		List<Todo> todos = jdbcTemplate.query(sql, todoRowMapper(), id);
 
 		return todos.stream().findAny();
@@ -30,7 +30,7 @@ public class TodoJdbcRepository implements TodoRepository {
 
 	@Override
 	public List<Todo> findAllTodos() {
-		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO";
+		String sql = "SELECT id, title, contents, user, status, created_at, updated_at FROM TODO WHERE DELETED = 0";
 		List<Todo> todos = jdbcTemplate.query(sql, todoRowMapper());
 		return todos;
 	}
@@ -57,8 +57,8 @@ public class TodoJdbcRepository implements TodoRepository {
 
 	@Override
 	public boolean deleteById(Long id) {
-		// 구현 중
-		return false;
+		String sql = "UPDATE TODO SET deleted = 1 WHERE id = ?";
+		return jdbcTemplate.update(sql, id) == 1;
 	}
 
 	public RowMapper<Todo> todoRowMapper() {

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoJdbcRepository.java
@@ -55,6 +55,12 @@ public class TodoJdbcRepository implements TodoRepository {
 		return todo;
 	}
 
+	@Override
+	public boolean deleteById(Long id) {
+		// 구현 중
+		return false;
+	}
+
 	public RowMapper<Todo> todoRowMapper() {
 		return (rs, rowNum) -> {
 			Todo todo = new Todo(

--- a/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
+++ b/BE/src/main/java/codesquad/be/todoserver/repository/TodoRepository.java
@@ -13,4 +13,6 @@ public interface TodoRepository {
 	List<Todo> findAllTodos();
 
 	Todo saveTodo(Todo todo);
+
+	boolean deleteById(Long id);
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -47,7 +47,8 @@ public class TodoService {
 	}
 
 	public boolean deleteById(Long id) {
-			// 구현 중
-		return false;
+		todoRepository.findById(id)
+			.orElseThrow(() -> new NoSuchTodoFoundException("id: " + id));
+		return todoRepository.deleteById(id);
 	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -45,4 +45,9 @@ public class TodoService {
 		historyRepository.saveHistory(history);
 		return saveTodo;
 	}
+
+	public boolean deleteById(Long id) {
+			// 구현 중
+		return false;
+	}
 }

--- a/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
+++ b/BE/src/main/java/codesquad/be/todoserver/service/TodoService.java
@@ -2,6 +2,7 @@ package codesquad.be.todoserver.service;
 
 import codesquad.be.todoserver.controller.TodoDtoMapper;
 import codesquad.be.todoserver.controller.model.RegisterTodoDto;
+import codesquad.be.todoserver.domain.Action;
 import codesquad.be.todoserver.domain.History;
 import codesquad.be.todoserver.domain.Todo;
 import codesquad.be.todoserver.exception.NoSuchTodoFoundException;
@@ -41,14 +42,15 @@ public class TodoService {
 		Todo saveTodo = todoRepository.saveTodo(
 			TodoDtoMapper.toDomainFromRegisterTodoDto(registerTodoDto));
 
-		History history = History.createAddHistoryBy(saveTodo);
-		historyRepository.saveHistory(history);
+		historyRepository.saveHistory(History.of(saveTodo, Action.ADD));
 		return saveTodo;
 	}
 
 	public boolean deleteById(Long id) {
-		todoRepository.findById(id)
+		Todo todo = todoRepository.findById(id)
 			.orElseThrow(() -> new NoSuchTodoFoundException("id: " + id));
+
+		historyRepository.saveHistory(History.of(todo, Action.REMOVE));
 		return todoRepository.deleteById(id);
 	}
 }

--- a/BE/src/main/resources/db/schema.sql
+++ b/BE/src/main/resources/db/schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE TODO
     status       VARCHAR(10)                    COMMENT 'Todo의 상태(todo, doing, done)',
     created_at   TIMESTAMP                      COMMENT 'Todo 생성 시간',
     updated_at   TIMESTAMP                      COMMENT 'Todo 업데이트 시간',
+    deleted      BIT NOT NULL DEFAULT 0         COMMENT 'Todo 삭제 여부',
     PRIMARY KEY (id)
 );
 

--- a/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/controller/TodoControllerTest.java
@@ -1,6 +1,7 @@
 package codesquad.be.todoserver.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -64,6 +65,18 @@ class TodoControllerTest {
 		perform
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+	}
+
+	@Test
+	void 특정_투두_삭제_성공() throws Exception {
+		List<Todo> todos = createTestData();
+
+		given(todoService.getById(1L))
+			.willReturn(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));
+
+		ResultActions perform = mockMvc.perform(delete("/api/todos/1"));
+
+		perform.andExpect(status().isNoContent());
 	}
 
 	private List<Todo> createTestData() {

--- a/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/repository/TodoRepositoryTest.java
@@ -51,4 +51,11 @@ class TodoRepositoryTest {
 
 		assertThat(todos).hasSize(4);
 	}
+
+	@Test
+	void 특정_투두_삭제_성공() {
+		boolean result = todoRepository.deleteById(1L);
+
+		assertThat(result).isTrue();
+	}
 }

--- a/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
+++ b/BE/src/test/java/codesquad/be/todoserver/service/TodoServiceTest.java
@@ -65,6 +65,18 @@ class TodoServiceTest {
 		assertThat(todos).contains(todolist.get(1));
 	}
 
+	@Test
+	void 특정_투두_삭제_성공() {
+		given(todoRepository.findById(2L))
+			.willReturn(Optional.of(new Todo(2L, "Github 공부하기", "add, commit, push", "sam", "todo")));
+		given(todoRepository.deleteById(2L))
+			.willReturn(true);
+
+		boolean result = todoService.deleteById(2L);
+
+		assertThat(result).isTrue();
+	}
+
 	private List<Todo> createTestData() {
 		List<Todo> todolist = new ArrayList<>();
 		todolist.add(new Todo(1L, "Github 공부하기", "add, commit, push", "sam", "todo"));

--- a/BE/src/test/resources/testDB/schema.sql
+++ b/BE/src/test/resources/testDB/schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE TODO
     status       VARCHAR(10)                    COMMENT 'Todo의 상태(todo, doing, done)',
     created_at   TIMESTAMP                      COMMENT 'Todo 생성 시간',
     updated_at   TIMESTAMP                      COMMENT 'Todo 업데이트 시간',
+    deleted      BIT NOT NULL DEFAULT 0         COMMENT 'Todo 삭제 여부',
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
### 📝 Description

안드로이드 클라이언트가 특정 Todo 를 삭제한다

### 💽 Commits

## 요청 세부사항

성공
- DELETE /api/todos/{id} 요청 값을 받는다.
- DB 에서 해당 id todo 를 찾아온다.
- 해당 todo 를 simple delete 하기 위해 삭제 유무 상태를 변경한다.
- 상태 코드만 반환한다. (204 No Contents)
- DB 의 HISTORY table 에 삭제 history 추가


### 🖼 결과

<img width="422" alt="Screen Shot 2022-04-14 at 11 48 22 AM" src="https://user-images.githubusercontent.com/73376468/163303900-fce1f8c8-6a42-4784-90d4-78c886365cc1.png">

